### PR TITLE
Change hello to hollow

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,6 @@
 using namespace std;
 
 int main() {
-	cout << "Hello world." << endl;
+	cout << "Hollow World." << endl;
 	return 0;
 }


### PR DESCRIPTION
Hello world is typo.
Hollow World is correct.
I changed it.

Please review the change.